### PR TITLE
`literal` option not works for `fwmkeys`

### DIFF
--- a/pyrant/__init__.py
+++ b/pyrant/__init__.py
@@ -161,7 +161,7 @@ class Tyrant(object):
             flat = list(itertools.chain(*((k, utils.from_python(v)) for
                                            k,v in value.iteritems())))
             args = [key] + flat
-            self.proto.misc('put', args)  # EXPLAIN why is this hack necessary?
+            self.proto.misc('put', args, literal=self.literal)  # EXPLAIN why is this hack necessary?
         else:
             if isinstance(value, (list, tuple)):
                 assert self.separator, "Separator is not set"
@@ -361,7 +361,7 @@ class Tyrant(object):
         if not isinstance(keys, (list, tuple)):
             keys = list(keys)
 
-        self.proto.misc('outlist', keys, opts)
+        self.proto.misc('outlist', keys, opts, literal=self.literal)
 
     def multi_get(self, keys):
         """
@@ -381,7 +381,7 @@ class Tyrant(object):
         prep_val = lambda v: utils.to_python(v, self.db_type, self.separator)
 
         keys = list(keys)
-        data = self.proto.misc('getlist', keys, 0)
+        data = self.proto.misc('getlist', keys, 0, literal=self.literal)
         data_keys = data[::2]
         data_vals = (prep_val(x) for x in data[1::2])
         return zip(data_keys, data_vals)
@@ -437,7 +437,7 @@ class Tyrant(object):
                 value = self.separator.join(strings)
             ready_pairs.extend((key, value))
 
-        self.proto.misc('putlist', ready_pairs, opts)
+        self.proto.misc('putlist', ready_pairs, opts, literal=self.literal)
 
     def prefix_keys(self, prefix, maxkeys=None):
         """

--- a/pyrant/__init__.py
+++ b/pyrant/__init__.py
@@ -448,7 +448,7 @@ class Tyrant(object):
         if maxkeys is None:
             maxkeys = len(self)
 
-        return self.proto.fwmkeys(prefix, maxkeys)
+        return self.proto.fwmkeys(prefix, maxkeys, self.literal)
 
     def sync(self):
         """

--- a/pyrant/protocol.py
+++ b/pyrant/protocol.py
@@ -404,13 +404,14 @@ class TyrantProtocol(object):
         self._sock.send(self.ITERNEXT)
         return self._sock.get_unicode()
 
-    def fwmkeys(self, prefix, maxkeys=-1):
+    def fwmkeys(self, prefix, maxkeys=-1, literal=False):
         """
         Get up to the first maxkeys starting with prefix
         """
         self._sock.send(self.FWMKEYS, _ulen(prefix), maxkeys, prefix)
         numkeys = self._sock.get_int()
-        return [self._sock.get_unicode() for i in xrange(numkeys)]
+        fn = self._sock.get_str if literal else self._sock.get_unicode
+        return [fn() for i in xrange(numkeys)]
 
     def addint(self, key, num=0):
         """

--- a/pyrant/protocol.py
+++ b/pyrant/protocol.py
@@ -653,7 +653,7 @@ class TyrantProtocol(object):
 
         return self.misc('search', args, opts)
 
-    def misc(self, func, args, opts=0):
+    def misc(self, func, args, opts=0, literal=False):
         """
         Executes custom function.
 
@@ -683,4 +683,5 @@ class TyrantProtocol(object):
         finally:
             numrecs = self._sock.get_int()
 
-        return [self._sock.get_unicode() for i in xrange(numrecs)]
+        fn = self._sock.get_str if literal else self._sock.get_unicode
+        return [fn() for i in xrange(numrecs)]


### PR DESCRIPTION
This pull request is the hotfix for this problem.
